### PR TITLE
Added asynchronous and string support to the UART class

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,6 +100,37 @@ void ControlUpdate()
     UpdateMotors(&mspeed1, &mspeed2, &mspeed3, &mspeed4);
 }
 
+/** Dummy callback functions - fill these out with correct commands/function calls later **/
+void StopMotors() {
+    pc.printf("stop quadcopter\r\n");
+
+    // add code to stop motors in an emergency
+}
+
+void Heartbeat() {
+    comm.send_data((uint8_t *) "OK");
+}
+
+void SetMotor(uint8_t motor, uint8_t value) {
+    pc.printf("set motor %d to %d\r\n", motor, value);
+
+    // add code to change individual motor/ESC
+}
+
+uint32_t SetPositionRotation(uint8_t mode, uint32_t value) {
+    pc.printf("move %d %d\r\n", mode, value);
+
+    // parse mode (X/Y/Z position/rotation set/get)
+    return 0;
+}
+
+uint32_t SetIMU(uint8_t mode) {
+    pc.printf("imu %d\r\n", mode);
+
+    // get/set IMU values
+    return 0;
+}
+
 int main()
 {
     pc.printf("Initializing Motors...\r\n");
@@ -113,6 +144,7 @@ int main()
     
     pc.printf("Initializing Communications...\r\n");
     comm.init();
+    comm.register_callbacks(&StopMotors, &Heartbeat, &SetPositionRotation, &SetMotor, &SetIMU);
 
     pc.printf("Arming Motors...\r\n");
     ArmMotors();
@@ -122,11 +154,5 @@ int main()
         comm.process_frames();
         GetAngleMeasurements();
         ControlUpdate();  
-
-        // maybe place this in its own thread/interrupt-driven callback
-        uint8_t message = comm.get_message_byte();
-        if(message != 0) {
-            pc.printf("Received byte %x\r\n", message);
-        }
     }
 }

--- a/src/xbeeuart.cpp
+++ b/src/xbeeuart.cpp
@@ -6,6 +6,12 @@ using namespace XBeeLib;
 
 uint8_t XBeeUART::recent_msg_byte_ = 0;
 
+UARTBasicCallback_t  XBeeUART::stopcallback_ = NULL;
+UARTBasicCallback_t  XBeeUART::heartbeatcallback_ = NULL;
+UARTMoveCallback_t  XBeeUART::movecallback_ = NULL;
+UARTMotorCallback_t XBeeUART::motorcallback_ = NULL;
+UARTIMUCallback_t   XBeeUART::imucallback_ = NULL;
+
 XBeeUART::XBeeUART() {
     remote_device_ = NULL;
 }
@@ -18,6 +24,19 @@ void XBeeUART::init() {
     xbee_ = new XBee802(RADIO_TX, RADIO_RX, RADIO_RESET, RADIO_RTS, RADIO_CTS, 9600); // constants in config.h
     xbee_->register_receive_cb(&receive_cb_);
     xbee_->init();
+}
+
+uint8_t XBeeUART::register_callbacks(UARTBasicCallback_t stop, UARTBasicCallback_t heartbeat, UARTMoveCallback_t move, UARTMotorCallback_t motor, UARTIMUCallback_t imu) {
+    stopcallback_ = stop;
+    heartbeatcallback_ = heartbeat;
+    movecallback_ = move;
+    motorcallback_ = motor;
+    imucallback_ = imu;
+
+    if(stopcallback_ == NULL || heartbeatcallback_ == NULL || movecallback_ == NULL || motorcallback_ == NULL || imucallback_ == NULL)
+        return 1;
+    else
+        return 0;
 }
 
 void XBeeUART::process_frames() {
@@ -57,12 +76,60 @@ uint8_t XBeeUART::send_data(uint8_t data[]) {
 }
 
 void XBeeUART::receive_cb_(const RemoteXBee802& remote, bool broadcast, const uint8_t *const data, uint16_t len) {
-    // process data - future implementation
-    
-
-
     // set as the most recent message, if valid
     if(!broadcast && len > 0 && data[0] != 0) {
         recent_msg_byte_ = data[0];
+    }
+
+    // parse the message, and use callbacks if available
+    if(!broadcast && len >= 2) {
+        // get command from message
+        char command[2];
+        memcpy(command, data, 2);
+        if(!strncmp("SA", command, 2)) {
+            stopcallback_();
+        } else if(!strncmp("HB", command, 2)) {
+            heartbeatcallback_();
+        } else if(!strncmp("IR", command, 2)) {
+            imucallback_(IMU_RST);
+        } else {
+            // get value from message
+            char value_string[11];
+            memcpy(value_string, &data[2], len - 2); // copy characters 2 through len
+            uint32_t value = atoi(value_string);
+            if(!strncmp("XP", command, 2)) {
+                movecallback_(POS_X, value);
+            } else if(!strncmp("YP", command, 2)) {
+                movecallback_(POS_Y, value);
+            } else if(!strncmp("ZP", command, 2)) {
+                movecallback_(POS_Z, value);
+            } else if(!strncmp("XR", command, 2)) {
+                movecallback_(ROT_X, value);
+            } else if(!strncmp("YR", command, 2)) {
+                movecallback_(ROT_Y, value);
+            } else if(!strncmp("ZR", command, 2)) {
+                movecallback_(ROT_Z, value);
+            } else if(!strncmp("PX", command, 2)) {
+                movecallback_(GET_POS_X, value);
+            } else if(!strncmp("PY", command, 2)) {
+                movecallback_(GET_POS_Y, value);
+            } else if(!strncmp("PZ", command, 2)) {
+                movecallback_(GET_POS_Z, value);
+            } else if(!strncmp("RX", command, 2)) {
+                movecallback_(GET_ROT_X, value);
+            } else if(!strncmp("RY", command, 2)) {
+                movecallback_(GET_ROT_Y, value);
+            } else if(!strncmp("RZ", command, 2)) {
+                movecallback_(GET_ROT_Z, value);
+            } else if(!strncmp("M1", command, 2)) {
+                motorcallback_(ESC_1, value);
+            } else if(!strncmp("M2", command, 2)) {
+                motorcallback_(ESC_2, value);
+            } else if(!strncmp("M3", command, 2)) {
+                motorcallback_(ESC_3, value);
+            } else if(!strncmp("M4", command, 2)) {
+                motorcallback_(ESC_4, value);
+            }
+        }
     }
 }

--- a/src/xbeeuart.h
+++ b/src/xbeeuart.h
@@ -15,9 +15,37 @@
 #include "stdint.h"
 #include "XBeeLib.h"
 
+/**
+ * Motor/movement mode definitions - should this be moved to config.h?
+ *  These values could then be used elsewhere
+ */
+#define POS_X     0
+#define POS_Y     1
+#define POS_Z     2
+#define ROT_X     3
+#define ROT_Y     4
+#define ROT_Z     5
+#define GET_POS_X 6
+#define GET_POS_Y 7
+#define GET_POS_Z 8
+#define GET_ROT_X 9
+#define GET_ROT_Y 10
+#define GET_ROT_Z 11
+#define ESC_1     1
+#define ESC_2     2
+#define ESC_3     3
+#define ESC_4     4
+#define IMU_RST   0
+
+typedef void     (*UARTBasicCallback_t)();
+typedef uint32_t (*UARTMoveCallback_t)(uint8_t, uint32_t);
+typedef void     (*UARTMotorCallback_t)(uint8_t, uint8_t);
+typedef uint32_t (*UARTIMUCallback_t)(uint8_t);
+
 class XBeeUART
 {
 public:
+
     /**
      * XBee UART constructor.
      *
@@ -29,6 +57,12 @@ public:
      * Initialize XBee module
      */
     void init();
+
+    /**
+     * Register callbacks to be used whenever a message is received. The callbacks are run
+     * as soon as a message is received, depending on the message content and/or command.
+     */
+    uint8_t register_callbacks(UARTBasicCallback_t stop, UARTBasicCallback_t heartbeat, UARTMoveCallback_t move, UARTMotorCallback_t motor, UARTIMUCallback_t imu);
 
     /**
      * Get most recent message (first byte, anyway) received by the radio.
@@ -64,6 +98,11 @@ private:
     XBeeLib::RemoteXBee802 *remote_device_;
     static void receive_cb_(const XBeeLib::RemoteXBee802& remote, bool broadcast, const uint8_t *const data, uint16_t len);
     static uint8_t recent_msg_byte_;
+    static UARTBasicCallback_t  stopcallback_;
+    static UARTBasicCallback_t  heartbeatcallback_;
+    static UARTMoveCallback_t  movecallback_;
+    static UARTMotorCallback_t motorcallback_;
+    static UARTIMUCallback_t   imucallback_;
 };
 
 #endif


### PR DESCRIPTION
Added functionality, and tested with the Nucleo and XBee modules. Spaces and negatives from the base station work, and response is almost instantaneous. I based the protocol on the document from Issue #4.

Some functions have also been added to main.cpp as frameworks - they should have functions/features added to them as development progresses.
