### PR TITLE
Added PID value changes through XBee communications

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -36,6 +36,13 @@ Note that all of these override position/rotation commands.
  * `TH #` Set throttle for all four motors. Data is a 16-bit unsigned integer.
  * `AT`   Set Motor control back to automatic (PID) mode.
 
+### PID commands
+These commands set constants (Kp, Ki, Kd) for the PID controller, and are applied as soon as they are interpreted. Note that settings these do not set motor control to automatic mode.
+
+ * `KP #.#` Set Kp to a certain value. Data is a 32-bit float.
+ * `KI #.#` Set Ki to a certain value. Data is a 32-bit float.
+ * `KD #.#` Set Kd to a certain value. Data is a 32-bit float.
+
 ### IMU commands
 For retrieving positions and rotations, see the "Position/Rotation commands" section.
 

--- a/src/PID/pid.cpp
+++ b/src/PID/pid.cpp
@@ -1,9 +1,9 @@
 #include "mbed.h"
 #include "pid.h"
 
-PID roll_controller(&pid_roll_in, &pid_roll_out, &pid_roll_setpoint, 5.0, 0.0, 0.0, REVERSE);
-PID pitch_controller(&pid_pitch_in, &pid_pitch_out, &pid_pitch_setpoint, 5.0, 0.0, 0.0, REVERSE);
-PID yaw_controller(&pid_yaw_in, &pid_yaw_out, &pid_yaw_setpoint, 5.0, 0.0, 0.0, DIRECT);
+PID roll_controller(&pid_roll_in, &pid_roll_out, &pid_roll_setpoint, KP, KI, KD, REVERSE);
+PID pitch_controller(&pid_pitch_in, &pid_pitch_out, &pid_pitch_setpoint, KP, KI, KD, REVERSE);
+PID yaw_controller(&pid_yaw_in, &pid_yaw_out, &pid_yaw_setpoint, KP, KI, KD, DIRECT);
 
 PID::PID(float* Input, float* Output, float* Setpoint,
          float Kp, float Ki, float Kd, int ControllerDirection)
@@ -167,4 +167,11 @@ void PIDCompute(void)
     roll_controller.Compute();
     pitch_controller.Compute();
     yaw_controller.Compute();
+}
+
+void PIDSetConstants(float kp, float ki, float kd)
+{
+    roll_controller.SetTunings(kp, ki, kd);
+    pitch_controller.SetTunings(kp, ki, kd);
+    yaw_controller.SetTunings(kp, ki, kd);
 }

--- a/src/PID/pid.h
+++ b/src/PID/pid.h
@@ -7,6 +7,10 @@ extern float pid_roll_setpoint, pid_pitch_setpoint, pid_yaw_setpoint;
 extern float roll, pitch, yaw;
 extern Timer t;
 
+#define KP 5.0
+#define KI 0.0
+#define KD 0.0
+
 /*
  * PID - A PID controller implementation.
  *
@@ -49,8 +53,8 @@ public:
     #define MANUAL    0
     #define DIRECT    0
     #define REVERSE   1
-    #define PID_OUT_MIN 1000
-    #define PID_OUT_MAX 1900
+    #define PID_OUT_MIN -200
+    #define PID_OUT_MAX 200
       
     PID(float* Input, float* Output, float* Setpoint,
         float Kp, float Ki, float Kd, int ControllerDirection);
@@ -74,5 +78,6 @@ public:
 void PIDInit(int SampleTime);
 void PIDUpdate(void);
 void PIDCompute(void);
+void PIDSetConstants(float kp, float ki, float kd);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,6 +214,25 @@ uint32_t SetPositionRotation(uint8_t mode, uint32_t value) {
     return 0;
 }
 
+void SetPID(uint8_t mode, float value) {
+    // if values are zero, leave them alone
+    float kp = KP;
+    float ki = KI;
+    float kd = KD;
+    if(mode == UART_KP)
+        kp = value;
+    else if(mode == UART_KI)
+        ki = value;
+    else if(mode == UART_KD)
+        kd = value;
+
+    #ifdef DEBUG
+    pc.printf("setpid %d %d %d (x100)\r\n", (int)(kp*100), (int)(ki*100), (int)(kd*100));
+    #endif
+
+    PIDSetConstants(kp, ki, kd);
+}
+
 uint32_t SetIMU(uint8_t mode) {
     
     #ifdef DEBUG
@@ -248,7 +267,7 @@ int main()
     pc.printf("Initializing Communications...\r\n");
     #endif
     comm.init();
-    comm.register_callbacks(&StopMotors, &Heartbeat, &SetPositionRotation, &SetMotor, &SetIMU);
+    comm.register_callbacks(&StopMotors, &Heartbeat, &SetPositionRotation, &SetMotor, &SetIMU, &SetPID);
     commticker.attach(&comm, &XBeeUART::process_frames, 0.1); // process received frames at 10 Hz
 
     #ifdef DEBUG

--- a/src/xbeeuart.h
+++ b/src/xbeeuart.h
@@ -30,6 +30,9 @@
 #define ESC_3     3
 #define ESC_4     4
 #define THROTTLE  5
+#define UART_KP   0
+#define UART_KI   1
+#define UART_KD   2
 #define ESC_AUTO  6
 #define IMU_RST   0
 
@@ -37,6 +40,7 @@ typedef void     (*UARTBasicCallback_t)();
 typedef uint32_t (*UARTMoveCallback_t)(uint8_t, uint32_t);
 typedef void     (*UARTMotorCallback_t)(uint8_t, uint16_t);
 typedef uint32_t (*UARTIMUCallback_t)(uint8_t);
+typedef void     (*UARTPIDCallback_t)(uint8_t, float);
 
 class XBeeUART
 {
@@ -58,7 +62,7 @@ public:
      * Register callbacks to be used whenever a message is received. The callbacks are run
      * as soon as a message is received, depending on the message content and/or command.
      */
-    uint8_t register_callbacks(UARTBasicCallback_t stop, UARTBasicCallback_t heartbeat, UARTMoveCallback_t move, UARTMotorCallback_t motor, UARTIMUCallback_t imu);
+    uint8_t register_callbacks(UARTBasicCallback_t stop, UARTBasicCallback_t heartbeat, UARTMoveCallback_t move, UARTMotorCallback_t motor, UARTIMUCallback_t imu, UARTPIDCallback_t pid);
 
     /**
      * Get most recent message (first byte, anyway) received by the radio.
@@ -99,6 +103,7 @@ private:
     static UARTMoveCallback_t  movecallback_;
     static UARTMotorCallback_t motorcallback_;
     static UARTIMUCallback_t   imucallback_;
+    static UARTPIDCallback_t   pidcallback_;
 };
 
 #endif


### PR DESCRIPTION
Added default #defines for Kp, Ki, Kd, and added a callback (and supporting code) for the UART class.

I also changed the PID min/max values to something that works; we changed it last Wednesday but it looks like this was never committed/pushed to develop.
